### PR TITLE
Cleanup async stuff and class declarations

### DIFF
--- a/lib/apis/bans.js
+++ b/lib/apis/bans.js
@@ -21,24 +21,24 @@ class bans {
 					'[Ksoft API] user, reason, and proof fields are required'
 				);
 
-      if (typeof jsonBanData.appeal_possible === 'boolean') {
-        jsonBanData.appeal_possible = jsonBanData.appeal_possible.toString();
-      }
+			if (typeof jsonBanData.appeal_possible === 'boolean') {
+				jsonBanData.appeal_possible = jsonBanData.appeal_possible.toString();
+			}
 
 			return http(this.baseURL, 'POST')
-			  .path('/bans/add')
+				.path('/bans/add')
 				.header('Authorization', `Bearer ${this.token}`)
 				.body(jsonBanData, 'form')
-         .send()
-         .then(res => res.json());
-    }
+				 .send()
+				 .then(res => res.json());
+		}
 
-    return http(this.baseURL, 'POST')
+		return http(this.baseURL, 'POST')
 				.path('/bans/add')
 				.header('Authorization', `Bearer ${this.token}`)
 				.body(banData, 'form')
-        .send()
-        .then(res => res.json());
+				.send()
+				.then(res => res.json());
 	}
 	/**
 	 * @param {String} userID The userID of the person you want to get info for
@@ -47,14 +47,14 @@ class bans {
 	getBanInfo(userID) {
 		if (!userID) throw new Error('[Ksoft API] Please specify user ID');
 		if (typeof userID !== 'string')
-      throw new Error('[Ksoft API] userID must be a string');
+			throw new Error('[Ksoft API] userID must be a string');
 
-    return http(this.baseURL)
+		return http(this.baseURL)
 				.path('/bans/info')
 				.header('Authorization', `Bearer ${this.token}`)
 				.query('user', userID)
-        .send()
-        .then(res => res.json());
+				.send()
+				.then(res => res.json());
 	}
 	/**
 	 * @param {String} userID The user id for the person being banned
@@ -63,14 +63,14 @@ class bans {
 	check(userID) {
 		if (!userID) throw new Error('[Ksoft API] Please specify user ID');
 		if (typeof userID !== 'string')
-      throw new Error('[Ksoft API] userID must be a string');
+			throw new Error('[Ksoft API] userID must be a string');
 
-    return http(this.baseURL)
+		return http(this.baseURL)
 				.path('/bans/check')
 				.header('Authorization', `Bearer ${this.token}`)
 				.query('user', userID)
-        .send()
-        .then(res => res.json());
+				.send()
+				.then(res => res.json());
 	}
 	/**
 	 *
@@ -87,8 +87,8 @@ class bans {
 				.path('/bans/list')
 				.query(params)
 				.header('Authorization', `Bearer ${this.token}`)
-        .send()
-        .then(res => res.json());
+				.send()
+				.then(res => res.json());
 	}
 	/**
 	 * @param {Number} epochDate An epoch date. Example: 1539915420 (October 19 2018)
@@ -104,8 +104,8 @@ class bans {
 				.path('/bans/updates')
 				.query('timestamp', epochDate)
 				.header('Authorization', `Bearer ${this.token}`)
-        .send()
-        .then(res => res.json());
+				.send()
+				.then(res => res.json());
 	}
 	/**
 	 *
@@ -122,21 +122,21 @@ class bans {
 		if (moreInfo) options.more_info = moreInfo;
 
 		if (advancedBannedOnly) {
-      return http(this.baseURL)
-        .path('/bans/bulkcheck')
-        .header('Authorization', `Bearer ${this.token}`)
-        .query({
-          users: ids.join(','),
-          more_info: true
-        })
-        .send()
-        .then(res => res.json())
-        .then(bans => bans.filter(b => b.is_ban_active));
+			return http(this.baseURL)
+				.path('/bans/bulkcheck')
+				.header('Authorization', `Bearer ${this.token}`)
+				.query({
+					users: ids.join(','),
+					more_info: true
+				})
+				.send()
+				.then(res => res.json())
+				.then(bans => bans.filter(b => b.is_ban_active));
 
 			//if (finalResult.length <= 1)
 				//throw new Error('there are no bans in the current array');
 		} else {
-      return http(this.baseURL)
+			return http(this.baseURL)
 				.path('/bans/bulkcheck')
 				.header('Authorization', `Bearer ${this.token}`)
 				.query(options)
@@ -156,9 +156,9 @@ class bans {
 		let members = guildMemberCollection.map(m => m.id);
 		if (ignoreBots) {
 			members = guildMemberCollection.filter(m => !m.user.bot).map(m => m.id);
-    }
+		}
 
-    return this.bulkCheck(members, {
+		return this.bulkCheck(members, {
 			moreInfo: moreInfo
 		});
 	}

--- a/lib/apis/bans.js
+++ b/lib/apis/bans.js
@@ -1,5 +1,6 @@
 const fetch = require('centra');
-let bans = class bans {
+
+class bans {
 	constructor(token) {
 		/** @access private*/
 		this.token = token;
@@ -12,7 +13,7 @@ let bans = class bans {
 	 * @param {banInfo} banData
 	 * @returns {Promise<BanAddResponse>} If the Post was successful or not
 	 */
-	async add(banData) {
+	add(banData) {
 		if (!banData) throw new Error('[Ksoft API] Please specify the banData');
 		if (banData._data) {
 			const jsonBanData = banData._data;
@@ -22,26 +23,16 @@ let bans = class bans {
 					'[Ksoft API] user, reason, and proof fields are required'
 				);
 
-			if (
-				jsonBanData.appeal_possible === false ||
-				jsonBanData.appeal_possible === true
-			) {
-				await (async () => {
-					return (jsonBanData.appeal_possible = `${
-						jsonBanData.appeal_possible
-					}`);
-				})();
-			}
-			try {
-				const res = await this.http(this.baseURL, 'POST')
-					.path('/bans/add')
-					.header('Authorization', 'Bearer ' + this.token)
-					.body(jsonBanData, 'form')
-					.send();
-				return res.json();
-			} catch (err) {
-				console.error(err);
-			}
+      if (typeof jsonBanData.appeal_possible === 'boolean') {
+        jsonBanData.appeal_possible = jsonBanData.appeal_possible.toString();
+      }
+
+			return this.http(this.baseURL, 'POST')
+			  .path('/bans/add')
+				.header('Authorization', `Bearer ${this.token}`)
+				.body(jsonBanData, 'form')
+         .send()
+         .then(res => res.json());
 		}
 
 		try {

--- a/lib/apis/bans.js
+++ b/lib/apis/bans.js
@@ -1,11 +1,9 @@
-const fetch = require('centra');
+const http = require('centra');
 
 class bans {
 	constructor(token) {
 		/** @access private*/
 		this.token = token;
-		/** @access private*/
-		this.http = fetch;
 		/** @access private*/
 		this.baseURL = 'https://api.ksoft.si';
 	}
@@ -27,62 +25,52 @@ class bans {
         jsonBanData.appeal_possible = jsonBanData.appeal_possible.toString();
       }
 
-			return this.http(this.baseURL, 'POST')
+			return http(this.baseURL, 'POST')
 			  .path('/bans/add')
 				.header('Authorization', `Bearer ${this.token}`)
 				.body(jsonBanData, 'form')
          .send()
          .then(res => res.json());
-		}
+    }
 
-		try {
-			const res = await this.http(this.baseURL, 'POST')
+    return http(this.baseURL, 'POST')
 				.path('/bans/add')
 				.header('Authorization', `Bearer ${this.token}`)
 				.body(banData, 'form')
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+        .send()
+        .then(res => res.json());
 	}
 	/**
 	 * @param {String} userID The userID of the person you want to get info for
 	 * @returns {Promise<BanInfoRespnse>} info about the ban
 	 */
-	async getBanInfo(userID) {
+	getBanInfo(userID) {
 		if (!userID) throw new Error('[Ksoft API] Please specify user ID');
 		if (typeof userID !== 'string')
-			throw new Error('[Ksoft API] userID must be a string');
-		try {
-			const res = await this.http(this.baseURL)
+      throw new Error('[Ksoft API] userID must be a string');
+
+    return http(this.baseURL)
 				.path('/bans/info')
 				.header('Authorization', `Bearer ${this.token}`)
 				.query('user', userID)
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+        .send()
+        .then(res => res.json());
 	}
 	/**
 	 * @param {String} userID The user id for the person being banned
 	 * @returns {Promise<banCheckResponse>} Whether or not the ban is active
 	 */
-	async check(userID) {
+	check(userID) {
 		if (!userID) throw new Error('[Ksoft API] Please specify user ID');
 		if (typeof userID !== 'string')
-			throw new Error('[Ksoft API] userID must be a string');
-		try {
-			const res = await this.http(this.baseURL)
+      throw new Error('[Ksoft API] userID must be a string');
+
+    return http(this.baseURL)
 				.path('/bans/check')
 				.header('Authorization', `Bearer ${this.token}`)
 				.query('user', userID)
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+        .send()
+        .then(res => res.json());
 	}
 	/**
 	 *
@@ -90,42 +78,34 @@ class bans {
 	 * @param {Number} perPage How many items per page
 	 * @returns {Promise<banListResponse>} List of ban objects
 	 */
-	async list(page, perPage) {
+	list(page, perPage) {
 		const params = {};
 		if (page) params.page = page;
 		if (perPage) params.per_page = perPage;
 
-		try {
-			const res = await this.http(this.baseURL)
+		return http(this.baseURL)
 				.path('/bans/list')
 				.query(params)
 				.header('Authorization', `Bearer ${this.token}`)
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+        .send()
+        .then(res => res.json());
 	}
 	/**
 	 * @param {Number} epochDate An epoch date. Example: 1539915420 (October 19 2018)
 	 * @returns {Promise<banUpdatesResponse>} List of bans on that date. will return empty array if nothing on that date
 	 */
-	async getUpdate(epochDate) {
+	getUpdate(epochDate) {
 		if (!epochDate)
 			throw new Error(
 				'[Ksoft API] Please specify an epochDate. Example: 1539915420'
 			);
 
-		try {
-			const res = await this.http(this.baseURL)
+		return http(this.baseURL)
 				.path('/bans/updates')
 				.query('timestamp', epochDate)
 				.header('Authorization', `Bearer ${this.token}`)
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+        .send()
+        .then(res => res.json());
 	}
 	/**
 	 *
@@ -135,42 +115,33 @@ class bans {
 	 * @param {Boolean} advancedBannedOnly Checks every user in the list given and filter out the people that are not banned and will return their whole ban object. Will throw an error if there are no banned people in the list. Use .catch() to manage the error
 	 * @returns {Promise<Array<bulkCheckResponse|simpleBanInfo>>} BulkCheck response
 	 */
-	async bulkCheck(ids, { bannedOnly, moreInfo, advancedBannedOnly }) {
+	bulkCheck(ids, { bannedOnly, moreInfo, advancedBannedOnly }) {
 		if (!ids) throw new Error("[Ksoft API] Please specify an array of id's");
 		const options = { users: ids.join(',') };
 		if (bannedOnly) options.banned_only = bannedOnly;
 		if (moreInfo) options.more_info = moreInfo;
 
-		async function getAdvancedBans() {
-			return await this.http(this.baseURL)
+		if (advancedBannedOnly) {
+      return http(this.baseURL)
+        .path('/bans/bulkcheck')
+        .header('Authorization', `Bearer ${this.token}`)
+        .query({
+          users: ids.join(','),
+          more_info: true
+        })
+        .send()
+        .then(res => res.json())
+        .then(bans => bans.filter(b => b.is_ban_active));
+
+			//if (finalResult.length <= 1)
+				//throw new Error('there are no bans in the current array');
+		} else {
+      return http(this.baseURL)
 				.path('/bans/bulkcheck')
 				.header('Authorization', `Bearer ${this.token}`)
-				.query({
-					users: ids.join(','),
-					more_info: true
-				})
+				.query(options)
 				.send()
 				.then(res => res.json());
-		}
-		if (advancedBannedOnly) {
-			const res = await getAdvancedBans.call(this);
-			const finalResult = res.filter(b => b.is_ban_active);
-
-			if (finalResult.length <= 1)
-				throw new Error('there are no bans in the current array');
-
-			return finalResult;
-		} else {
-			try {
-				const res = await this.http(this.baseURL)
-					.path('/bans/bulkcheck')
-					.header('Authorization', `Bearer ${this.token}`)
-					.query(options)
-					.send();
-				return res.json();
-			} catch (err) {
-				console.error(err);
-			}
 		}
 	}
 
@@ -181,16 +152,15 @@ class bans {
 	 * @param {Boolean} ignoreBots Whether you want the search to ignore bots
 	 * @returns {Promise<bulkCheckResponse|simpleBanInfo>} BulkCheck response
 	 */
-	async guildMembersCheck(guildMemberCollection, { moreInfo, ignoreBots }) {
+	guildMembersCheck(guildMemberCollection, { moreInfo, ignoreBots }) {
 		let members = guildMemberCollection.map(m => m.id);
 		if (ignoreBots) {
 			members = guildMemberCollection.filter(m => !m.user.bot).map(m => m.id);
-		}
-		const result = await this.bulkCheck(members, {
+    }
+
+    return this.bulkCheck(members, {
 			moreInfo: moreInfo
 		});
-
-		return result;
 	}
 };
 

--- a/lib/apis/images.js
+++ b/lib/apis/images.js
@@ -1,5 +1,6 @@
 const fetch = require('centra');
-let images = class images {
+
+class images {
 	constructor(token) {
 		/** @access private*/
 		this.token = token;
@@ -15,14 +16,10 @@ let images = class images {
 	 * Gets random meme from KSoft
 	 * @returns {Promise<getRandomMemeResponse>} Information for random meme
 	 */
-	async getRandomMeme() {
-		try {
-			const res = await this.http.path('/images/random-meme').send();
-
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+	getRandomMeme() {
+    return this.http.path('/images/random-meme')
+      .send()
+      .then(res => res.json());
 	}
 	/**
 	 * Gets random image from KSoft

--- a/lib/apis/images.js
+++ b/lib/apis/images.js
@@ -26,93 +26,71 @@ class images {
 	 * @param {String} tag tag for image
 	 * @returns {Promise<getRandomImageResponse>} Information for random image
 	 */
-	async getRandomImage(tag) {
-		try {
-			if (!tag) throw new Error('[Ksoft API] No tag found');
-			const res = await this.http
-				.path('/images/random-image')
-				.query('tag', tag)
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+	getRandomImage(tag) {
+		if (!tag) throw new Error('[Ksoft API] No tag found');
+		return this.http
+			.path('/images/random-image')
+			.query('tag', tag)
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @returns {Promise<getTagsResponse>} List of tags
 	 */
-	async getTags() {
-		try {
-			const res = await this.http.path('/images/tags').send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+	getTags() {
+		return this.http.path('/images/tags').send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {String} query Query for tags
 	 * @returns {Promise<searchTagsResponse>} Information about the specified tag
 	 */
-	async searchTags(query) {
+	searchTags(query) {
 		if (!query) throw new Error('[Ksoft API] Please define a search query');
-		try {
-			const res = await this.http
-				.path(`/images/tags/${encodeURIComponent(query)}`)
-				.send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+		return this.http
+			.path(`/images/tags/${encodeURIComponent(query)}`)
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {String} snowflake The url of the image you want to get
 	 * @returns {Promise<getImageFromIdResponse>} Information about the specified image
 	 */
-	async getImageFromId(snowflake) {
+	getImageFromId(snowflake) {
 		if (!snowflake)
 			throw new Error('[Ksoft API] Please define a unique image id');
-		try {
-			const res = await this.http.path(
-				`/images/image/${encodeURIComponent(snowflake)}`
-			);
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+		return this.http.path(
+			`/images/image/${encodeURIComponent(snowflake)}`
+		).then(res => res.json());
 	}
 	/**
 	 * @param {Boolean} nsfw Whether you want to allow nsfw content
 	 * @returns {Promise<getRandomWikiHowResponse>} Image and article information
 	 */
-	async getRandomWikiHow(nsfw) {
-		const res = await this.http
+	getRandomWikiHow(nsfw) {
+		return this.http
 			.path('/images/random-wikihow')
 			.query('nsfw', nsfw ? true : false)
-			.send();
-
-		return res.json();
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @returns {Promise<getRandomCutePictueResponse>} Information about the cute picture
 	 */
-	async getRandomCutePictue() {
-		try {
-			const res = await this.http.path('/images/random-aww').send();
-			return res.json();
-		} catch (err) {
-			console.error(err);
-		}
+	getRandomCutePictue() {
+		return this.http.path('/images/random-aww').send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {Boolean} gif Whether this should be a gif or not
 	 * @returns {Promise<getRandomNSFWResponse>} Information about the nsfw picture
 	 */
-	async getRandomNSFW(gif) {
-		const res = await this.http
+	getRandomNSFW(gif) {
+		return this.http
 			.path('/images/random-nsfw')
 			.query('gif', gif ? true : false)
-			.send();
-		return res.json();
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {String} subReddit Specified subreddit
@@ -120,18 +98,17 @@ class images {
 	 * @param {Boolean} removeNSFW Whether to remove nsfw content or not
 	 * @returns {Promise<getRandomRedditResponse>}
 	 */
-	async getRandomReddit(subReddit, span, removeNSFW) {
+	getRandomReddit(subReddit, span, removeNSFW) {
 		if (!subReddit) throw new Error('Please specify a subreddit');
 		const params = {};
 		if (span) params.span = span;
 		if (removeNSFW) params.remove_nsfw = removeNSFW;
 
-		const res = await this.http
+		return this.http
 			.path('/images/rand-reddit')
 			.query(params)
-			.send();
-
-		return res.json();
+			.send()
+			.then(res => res.json());
 	}
 };
 

--- a/lib/apis/images.js
+++ b/lib/apis/images.js
@@ -17,9 +17,9 @@ class images {
 	 * @returns {Promise<getRandomMemeResponse>} Information for random meme
 	 */
 	getRandomMeme() {
-    return this.http.path('/images/random-meme')
-      .send()
-      .then(res => res.json());
+		return this.http.path('/images/random-meme')
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * Gets random image from KSoft

--- a/lib/apis/kumo.js
+++ b/lib/apis/kumo.js
@@ -1,5 +1,6 @@
 const fetch = require('centra');
-let kumo = class kumo {
+
+class kumo {
 	constructor(token) {
 		/** @access private*/
 		this.token = token;

--- a/lib/apis/kumo.js
+++ b/lib/apis/kumo.js
@@ -21,18 +21,18 @@ class kumo {
 	 * @param {Boolean} includeMap Default: false, if to include an image of the area
 	 * @returns {Promise<searchResponse>} Information for the location
 	 */
-	async search(q, { fast, more, mapZoom, includeMap }) {
+	search(q, { fast, more, mapZoom, includeMap }) {
 		if (!q) throw new Error('[Ksoft API] Please define a search query');
 		const params = { q };
 		if (fast) params.fast = fast;
 		if (more) params.more = more;
 		if (mapZoom) params.map_zoom = mapZoom;
 		if (includeMap) params.include_map = includeMap;
-		const res = await this.http
+		return this.http
 			.path('/kumo/gis')
 			.query(params)
-			.send();
-		return res.json();
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {String} reportType  weather report type. Can be one of: "currently", "minutely", "hourly", "daily"
@@ -42,8 +42,8 @@ class kumo {
 	 * @param {String} icons Default: original, select icon pack
 	 * @returns {Promise<getSimpleWeatherResponse>} The information about the weather
 	 */
-	async getSimpleWeather(reportType, q, units, lang, icons) {
-		let reportTypes = ['currently', 'minutely', 'hourly', 'daily'];
+	getSimpleWeather(reportType, q, units, lang, icons) {
+		const reportTypes = ['currently', 'minutely', 'hourly', 'daily'];
 		if (!reportType)
 			throw new Error(
 				`[Ksoft API] Please define a valid report type. Types: ${reportTypes.join(
@@ -51,7 +51,7 @@ class kumo {
 				)}`
 			);
 		if (!q) throw new Error('[Ksoft API] Please define a search query');
-		if (reportTypes.some(report => report !== reportType))
+		if (!reportTypes.includes(reportType))
 			throw new Error(
 				`[Ksoft API] Please define a valid report type. Types: ${reportTypes.join(
 					' , '
@@ -61,11 +61,11 @@ class kumo {
 		if (units) params.units = units;
 		if (lang) params.lang = lang;
 		if (icons) params.icons = icons;
-		const res = await this.http
+		return this.http
 			.path(`/kumo/weather/${reportType}`)
 			.query(params)
-			.send();
-		return res.json();
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {Number} latitude The latitude of the location you are getting weather for
@@ -76,7 +76,7 @@ class kumo {
 	 * @param {String} icons Default: original, select icon pack
 	 * @returns {Promise<getAdvancedWeatherResponse>} The information about the weather
 	 */
-	async getAdvancedWeather(
+	getAdvancedWeather(
 		latitude,
 		longitude,
 		reportType,
@@ -84,14 +84,14 @@ class kumo {
 		lang,
 		icons
 	) {
-		let reportTypes = ['currently', 'minutely', 'hourly', 'daily'];
+		const reportTypes = ['currently', 'minutely', 'hourly', 'daily'];
 		if (!reportType)
 			throw new Error(
 				`[Ksoft API] Please define a valid report type. Types: ${reportTypes.join(
 					' , '
 				)}`
 			);
-		if (reportTypes.some(report => reportType !== report))
+		if (!reportTypes.includes(reportType))
 			throw new Error(
 				`[Ksoft API] Please define a valid report type. Types: ${reportTypes.join(
 					' , '
@@ -108,13 +108,13 @@ class kumo {
 		if (units) params.units = units;
 		if (lang) params.lang = lang;
 		if (icons) params.icons = icons;
-		const res = await this.http
+		return this.http
 			.path(
 				`/kumo/weather/${urlParams.slice(0, 2).join(',')}/${urlParams.pop()}}`
 			)
 			.query(params)
-			.send();
-		return res.json();
+			.send()
+			.then(res => res.json());
 	}
 	/**
 	 * @param {String} ip the ip address that you want to get information from

--- a/lib/apis/lyrics.js
+++ b/lib/apis/lyrics.js
@@ -1,5 +1,6 @@
 const fetch = require('centra');
-let lyrics = class lyrics {
+
+class lyrics {
 	constructor(token) {
 		/** @access private*/
 		this.token = token;

--- a/lib/apis/music.js
+++ b/lib/apis/music.js
@@ -18,16 +18,17 @@ class music {
 	 * @return {Promise<recommendationsResponse>}
 	 */
 
-	async recommendations(provider, tracks) {
+	recommendations(provider, tracks) {
 		if (!provider || !tracks)
 			throw new Error(
 				'[Ksoft API] Please specify the provider and tracks parameters'
 			);
-		const allowedProviders = ['youtube_ids', 'youtube', 'spotify'];
-		if (!allowedProviders.some(item => item === provider))
+
+		if (!['youtube_ids', 'youtube', 'spotify'].includes(provider))
 			throw new Error(
 				'[Ksoft API] Please specify the correct provider. Options: youtube_ids, youtube, or spotify'
 			);
+
 		if (typeof tracks === 'object') {
 			if (tracks.length < 1)
 				throw new Error('[Ksoft API] Please provide a track to search');
@@ -35,36 +36,37 @@ class music {
 				throw new Error(
 					'[Ksoft API] Please provide less than or equal to 5 tracks'
 				);
+		} else {
+			if (tracks.includes(',')) {
+				const trackArray = tracks.split(',');
+
+				if (trackArray.length < 1)
+					throw new Error('[Ksoft API] Please provide a track to search');
+				if (trackArray.length > 5)
+					throw new Error(
+						'[Ksoft API] Please provide less than or equal to 5 tracks'
+					);
+			} else if (tracks.includes('\n')) {
+				const trackArray = tracks.split('\n');
+
+				if (trackArray.length < 1)
+					throw new Error('[Ksoft API] Please provide a track to search');
+				if (trackArray.length > 5)
+					throw new Error(
+						'[Ksoft API] Please provide less than or equal to 5 tracks'
+					);
+			}
 		}
-		if (tracks.slice('').some(item => item === ',')) {
-			const trackArray = tracks.slice(',');
-			if (trackArray.length < 1)
-				throw new Error('[Ksoft API] Please provide a track to search');
-			if (trackArray.length > 5)
-				throw new Error(
-					'[Ksoft API] Please provide less than or equal to 5 tracks'
-				);
-		}
-		if (tracks.slice('').some(item => item === '\n')) {
-			const trackArray = tracks.slice('\n');
-			if (trackArray.length < 1)
-				throw new Error('[Ksoft API] Please provide a track to search');
-			if (trackArray.length > 5)
-				throw new Error(
-					'[Ksoft API] Please provide less than or equal to 5 tracks'
-				);
-		}
-		const res = await this.http.path('/music/recommendations').body({
+
+		return this.http.path('/music/recommendations').body({
 			provider: provider,
 			tracks: tracks
-		});
-
-		return res.json();
+		}).then(res => res.json());
 	}
 };
 
 module.exports = {
-  music
+	music
 };
 
 /**

--- a/lib/apis/music.js
+++ b/lib/apis/music.js
@@ -58,10 +58,8 @@ class music {
 			}
 		}
 
-		return this.http.path('/music/recommendations').body({
-			provider: provider,
-			tracks: tracks
-		}).then(res => res.json());
+		return this.http.path('/music/recommendations').body({ provider, tracks })
+			.then(res => res.json());
 	}
 };
 

--- a/lib/apis/music.js
+++ b/lib/apis/music.js
@@ -1,5 +1,6 @@
 const fetch = require('centra');
-module.exports = class music {
+
+class music {
 	constructor(token) {
 		/** @access private*/
 		this.token = token;
@@ -60,6 +61,10 @@ module.exports = class music {
 
 		return res.json();
 	}
+};
+
+module.exports = {
+  music
 };
 
 /**


### PR DESCRIPTION
Mostly a minor cleanup, rather than use await only to return another promise we can just return the promise directly with modifications on top via `.then`.

Class declarations don't need to be declared using `let`.